### PR TITLE
Increase the font size for deckJS slide

### DIFF
--- a/support/html/deckjs/pillar.deckjs.css
+++ b/support/html/deckjs/pillar.deckjs.css
@@ -1,0 +1,7 @@
+.deck-slide-scaler p, .deck-slide-scaler li, .deck-slide-scaler code {
+  font-size: 50px;
+}
+
+.deck-slide-scaler h2 {
+  font-size: 75px;
+}

--- a/support/templates/slides.deckjs.template
+++ b/support/templates/slides.deckjs.template
@@ -26,6 +26,9 @@
   <!-- Basic black and white print styles -->
   <link rel="stylesheet" media="print" href="../../support/html/deckjs/print.css">
 
+  <!-- Pillar extended style theme. -->
+  <link rel="stylesheet" media="screen" href="../../support/html/deckjs/pillar.deckjs.css">
+
   <!-- Required Modernizr file -->
   <script src="../../support/html/deckjs/modernizr.custom.js"></script>
 </head>


### PR DESCRIPTION
I had an extented theme for slide generated in DeckJS.

Just the font size was increase, all slides are now globally filled with texts

![slide_increase_text](https://cloud.githubusercontent.com/assets/948927/13917749/f5e4131a-ef62-11e5-81c9-1a5511756dd0.png)
